### PR TITLE
Fix tcp queries 

### DIFF
--- a/dns.py
+++ b/dns.py
@@ -42,6 +42,7 @@ class Dns(Base):
     """Log table for DNS entries."""
     __tablename__ = "dns"
     id = Column(Integer, primary_key=True)
+    transport = Column(String)
     src = Column(String)
     src_port = Column(Integer)
     dns_name = Column(String)
@@ -63,10 +64,12 @@ class HoneyDNSServerFactory(server.DNSServerFactory):
     def messageReceived(self, message, proto, address=None):
         # Log info.
         entry = {}
-        if address != None: # UDP
+        if address != None:
+            entry["transport"] = "UDP"
             entry["src_ip"] = address[0]
             entry["src_port"] = address[1]
-        else:               # TCP
+        else:
+            entry["transport"] = "TCP"
             entry["src_ip"] = proto.transport.getPeer().host
             entry["src_port"] = proto.transport.getPeer().port
         entry["dns_name"] = message.queries[0].name.name
@@ -91,7 +94,7 @@ class HoneyDNSServerFactory(server.DNSServerFactory):
     def log(self, data):
         if opts.verbose:
             print(data)
-        record = Dns(src=data["src_ip"], src_port=data["src_port"], dns_name=data["dns_name"], dns_type=data["dns_type"], dns_cls=data["dns_cls"])
+        record = Dns(transport=data["transport"], src=data["src_ip"], src_port=data["src_port"], dns_name=data["dns_name"], dns_type=data["dns_type"], dns_cls=data["dns_cls"])
         session.add(record)
         session.commit()
 

--- a/dns.py
+++ b/dns.py
@@ -63,8 +63,12 @@ class HoneyDNSServerFactory(server.DNSServerFactory):
     def messageReceived(self, message, proto, address=None):
         # Log info.
         entry = {}
-        entry["src_ip"] = address[0]
-        entry["src_port"] = address[1]
+        if address != None: # UDP
+            entry["src_ip"] = address[0]
+            entry["src_port"] = address[1]
+        else:               # TCP
+            entry["src_ip"] = proto.transport.getPeer().host
+            entry["src_port"] = proto.transport.getPeer().port
         entry["dns_name"] = message.queries[0].name.name
         entry["dns_type"] = dns.QUERY_TYPES.get(message.queries[0].type, dns.EXT_QUERIES.get(message.queries[0].type, "UNKNOWN (%d)" % message.queries[0].type))
         entry["dns_cls"] = dns.QUERY_CLASSES.get(message.queries[0].cls, "UNKNOWN (%d)" % message.queries[0].cls)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 SQLAlchemy==1.4.35
-Twisted==22.4.0
+Twisted==22.10.0
 


### PR DESCRIPTION
The Server listens for tcp queries but throws an exception when he handles one.

$ dig www.google.de -p 5053 +tcp @localhost

Traceback (most recent call last):
...
  File "/home/user/UDPot/dns.py", line 66, in messageReceived
    entry["src_ip"] = address[0]
builtins.TypeError: 'NoneType' object is not subscriptable

This is due to address being none if a stream protocol is used.
https://twisted.org/documents/21.2.0/api/twisted.names.server.DNSServerFactory.html#messageReceived
Get the ip and port from the protocol in this case.

Also added a column in the sqlite db for which protocol has been used.
This requires the removal of pre-existing databases because the schema changed.